### PR TITLE
Avoid taking 'default' twice for args in both signatures

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -39,6 +39,16 @@ def test_with_kwargs():
     assert str(signature(dest)) == '(d, a, b, e=2, c=1)'
 
 
+def test_when_kwargs_present_in_both():
+
+    def src(a, b, c=1, d=2): ...
+
+    @merge_args.merge_args(src)
+    def dest(e, c=1, d=2): ...
+
+    assert str(signature(dest)) == '(e, a, b, c=1, d=2)'
+
+
 def test_kwonlyargs():
 
     def src(q, w, e=1, *, r=2): pass


### PR DESCRIPTION
I noticed that the following fails (formatted as a unit test):

```python
def test_when_kwargs_present_in_both():

    def src(a, b, c=1, d=2): ...

    @merge_args.merge_args(src)
    def dest(e, c=1, d=2): ...

    assert str(signature(dest)) == '(e, a, b, c=1, d=2)'
```

With this output:

```sh
$ python -m pytest -k 'test_when_kwargs_present_in_both'
>       assert str(signature(dest)) == '(e, a, b, c=1, d=2)'
E       AssertionError: assert '(e, a=1, b=2, c=1, d=2)' == '(e, a, b, c=1, d=2)'
E         - (e, a, b, c=1, d=2)
E         + (e, a=1, b=2, c=1, d=2)
E         ?      ++   ++
```

As you can see, at present, merge_args takes the default values for arguments c and d from both functions, but the signature actually only has each of them once

This PR fixes this while keeping all other tests passing.