### PR TITLE
Adding drop_args and drop_kwonlyargs as additional parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ nosetests.xml
 
 # IntelliJ
 .idea
+
+# Visual Studio Code
+.vscode
+
+# virtual env
+.venv
+venv

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,21 @@ Usage
     def new(prefix, foo, *args, **kwargs):
         return old(prefix + foo, *args, **kwargs)
 
+or
+
+.. code:: python
+
+    from merge_args import merge_args
+
+    def old(foo, bar):
+        """This is old's docstring."""
+        print(foo, bar)
+        return foo + bar
+
+    @merge_args(old, drop_args=["bar"])
+    def new(prefix, foo, *args, **kwargs):
+        return old(prefix + foo, *args, **kwargs)
+
 If you then run ``help(new)``, this is the output:
 
 .. code:: text

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -65,6 +65,24 @@ def test_kwonlyargs():
 
     assert str(signature(dest2)) == '(*, a=2, b=3)'
 
+def test_drop_args():
+
+    def src(q, w, e=1, *, r=2): pass
+
+    @merge_args.merge_args(src, drop_args=["q"])
+    def dest(*, t=3, **kwargs): pass
+
+    assert str(signature(dest)) == '(w, e=1, *, t=3, r=2)'
+
+def test_drop_kwonlyargs():
+
+    def src(q, w, e=1, *, r=2): pass
+
+    @merge_args.merge_args(src, drop_kwonlyargs=["r"])
+    def dest(*, t=3, **kwargs): pass
+
+    assert str(signature(dest)) == '(q, w, e=1, *, t=3)'
+
 
 def test_var_fails():
 


### PR DESCRIPTION
Hi @Kwpolska, we stumbled across your article some years ago and have implemented your function a bit modified in our test application. Now, I have figured out that you are providing an own package for it.

Thus, in order to keep pace with your upstream changes, I have added our adaptations to your decorator. We explicitly have the need to drop some specific arguments from the merge and thus, I have added the two new parameters. I believe that more users could have that use case.

Finally, thanks for your effort and I would love to see my changes merged to main 😄.